### PR TITLE
Xin add option for star executable #51

### DIFF
--- a/bin/build_star_index
+++ b/bin/build_star_index
@@ -8,6 +8,7 @@ SEQUENCE_FASTA_DIR=$1
 GTF_FILE=$2
 NUM_THREADS=$3
 INDEX_DIR=$4
+STAR_EXECUTABLE=$5
 
 function list_files {
     local DELIMITER=$1
@@ -18,4 +19,4 @@ function list_files {
     echo ${LIST%$DELIMITER}    
 }
 
-STAR --runThreadN ${NUM_THREADS} --runMode genomeGenerate --genomeDir ${INDEX_DIR} --genomeFastaFiles $(list_files ' ' ${SEQUENCE_FASTA_DIR}/*.fa) --sjdbGTFfile ${GTF_FILE} --sjdbOverhang 100
+${STAR_EXECUTABLE} --runThreadN ${NUM_THREADS} --runMode genomeGenerate --genomeDir ${INDEX_DIR} --genomeFastaFiles $(list_files ' ' ${SEQUENCE_FASTA_DIR}/*.fa) --sjdbGTFfile ${GTF_FILE} --sjdbOverhang 100

--- a/bin/map_reads
+++ b/bin/map_reads
@@ -19,12 +19,13 @@ function star_se_reads {
     NUM_THREADS=$4
     READ_FILES=$5
     OUTPUT_DIR=$6
+    STAR_EXECUTABLE=$7
 
     ID=${SAMPLE}.${SPECIES}
     STAR_TMP=${ID}.tmp
     mkdir $STAR_TMP
 
-    STAR --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_FILES} --outFileNamePrefix ${STAR_TMP}/star --outSAMstrandField intronMotif --outSAMtype BAM Unsorted --readFilesCommand zcat --outFilterMultimapScoreRange 0 --outFilterMultimapNmax 10000
+    ${STAR_EXECUTABLE} --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_FILES} --outFileNamePrefix ${STAR_TMP}/star --outSAMstrandField intronMotif --outSAMtype BAM Unsorted --readFilesCommand zcat --outFilterMultimapScoreRange 0 --outFilterMultimapNmax 10000
 
     mv $STAR_TMP/starAligned.out.bam ${OUTPUT_DIR}/${ID}.bam
     mv $STAR_TMP/starLog.final.out ${OUTPUT_DIR}/${ID}.log.out
@@ -40,12 +41,13 @@ function star_pe_reads {
     READ_1_FILES=$5
     READ_2_FILES=$6
     OUTPUT_DIR=$7
+    STAR_EXECUTABLE=$8
 
     ID=${SAMPLE}.${SPECIES}
     STAR_TMP=${ID}.tmp
     mkdir $STAR_TMP
 
-    STAR --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_1_FILES} ${READ_2_FILES} --outFileNamePrefix ${STAR_TMP}/star --outSAMstrandField intronMotif --outSAMtype BAM Unsorted --readFilesCommand zcat --outFilterMultimapScoreRange 0 --outFilterMultimapNmax 10000
+    ${STAR_EXECUTABLE} --runThreadN ${NUM_THREADS} --genomeDir ${INDEX_DIR} --readFilesIn ${READ_1_FILES} ${READ_2_FILES} --outFileNamePrefix ${STAR_TMP}/star --outSAMstrandField intronMotif --outSAMtype BAM Unsorted --readFilesCommand zcat --outFilterMultimapScoreRange 0 --outFilterMultimapNmax 10000
 
     mv $STAR_TMP/starAligned.out.bam ${OUTPUT_DIR}/${ID}.bam
     mv $STAR_TMP/starLog.final.out ${OUTPUT_DIR}/${ID}.log.out
@@ -60,6 +62,7 @@ NUM_THREADS=$4
 INPUT_DIR=$5
 OUTPUT_DIR=$6
 READS_TYPE=$7
+STAR_EXECUTABLE=$8
 
 for species in ${SPECIES}; do
     for sample in ${SAMPLES}; do
@@ -68,9 +71,9 @@ for species in ${SPECIES}; do
         sample_reads_2_dir=${sample_dir}/reads_2
 
         if [[ "${READS_TYPE}" == "single" ]]; then
-            star_se_reads ${sample} ${species} ${STAR_INDICES_DIR}/${species} ${NUM_THREADS} $(listFiles ${sample_reads_1_dir}/*) ${OUTPUT_DIR}
+            star_se_reads ${sample} ${species} ${STAR_INDICES_DIR}/${species} ${NUM_THREADS} $(listFiles ${sample_reads_1_dir}/*) ${OUTPUT_DIR} ${STAR_EXECUTABLE}
         else
-            star_pe_reads ${sample} ${species} ${STAR_INDICES_DIR}/${species} ${NUM_THREADS} $(listFiles ${sample_reads_1_dir}/*) $(listFiles ${sample_reads_2_dir}/*) ${OUTPUT_DIR}
+            star_pe_reads ${sample} ${species} ${STAR_INDICES_DIR}/${species} ${NUM_THREADS} $(listFiles ${sample_reads_1_dir}/*) $(listFiles ${sample_reads_2_dir}/*) ${OUTPUT_DIR} ${STAR_EXECUTABLE}
         fi
     done
 done


### PR DESCRIPTION
added an option --star-executable to specify the STAR executable. 
Also works when the star index is not available for the specified STAR version, in which case, the index will be built using the specified STAR version.

Tested with mouse/rat test data in the pipeline_test folder in Sargasso.